### PR TITLE
`getUpdatesHistory` client method was added. Version was bumped to 1.2.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,11 @@
     "promise"
   ],
   "rules": {
+    "comma-dangle": ["error", {
+      "arrays": "ignore",
+      "functions": "never",
+      "objects": "ignore"
+    }],
     "import/no-extraneous-dependencies": [
       "error",
       {

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ This project uses `debug` module for verbose logging, to enable it, please launc
 your tests with env variable `DEBUG=TelegramServer:*`, like `DEBUG=TelegramServer:* ./node_modules/mocha/bin/mocha --use_strict --exit`.
 
 ## Changelog
+* 1.2.0 `getUpdatesHistory` client method was added
 * 1.1.1 `deleteMessage` API method was added
 * 1.0.7 Implement `GET` method for api
 * 1.0.6 Bump dependencies

--- a/modules/telegramClient.js
+++ b/modules/telegramClient.js
@@ -81,7 +81,6 @@ class TelegramClient {
   }
 
   getUpdates() {
-    const self = this;
     const message = {token: this.botToken};
     const options = {
       uri: `${this.url}/getUpdates`,
@@ -94,9 +93,24 @@ class TelegramClient {
           return Promise.resolve(update);
         }
         return Promise.delay(this.interval)
-          .then(()=>self.getUpdates());
+          .then(() => this.getUpdates());
       })
       .timeout(this.timeout, `did not get new updates in ${this.timeout} ms`);
+  }
+
+  /**
+   * Obtains all updates (messages or any other content) sent or received by specified bot.
+   * Doesn't mark updates as "read".
+   * Very useful for testing `deleteMessage` Telegram API method usage.
+   */
+  getUpdatesHistory() {
+    const json = {token: this.botToken};
+    return requestPromise({
+      uri: `${this.url}/getUpdatesHistory`,
+      method: 'POST',
+      json,
+    })
+      .then(ramda.prop('result'));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegram-test-api",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Emulating telegram API",
   "keywords": [
     "telegram",

--- a/routes/client/getUpdatesHistory.js
+++ b/routes/client/getUpdatesHistory.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/**
+ * Obtains all updates (messages or any other content) sent or received by specified bot.
+ * Doesn't mark updates as "read".
+ * Very useful for testing `deleteMessage` Telegram API method usage.
+ */
+const getUpdatesHistory = (app, telegramServer) => {
+  app.post('/getUpdatesHistory', (req, res, unusedNext) => {
+    const {token} = req.body;
+    res.sendResult({
+      ok: true,
+      result: telegramServer.getUpdatesHistory(token),
+    });
+  });
+};
+
+module.exports = getUpdatesHistory;

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,6 +10,7 @@ module.exports = [
 
   require('./client/sendMessage'),
   require('./client/getUpdates'),
+  require('./client/getUpdatesHistory'),
 ];
 
 /* eslint-enable global-require */

--- a/telegramServer.js
+++ b/telegramServer.js
@@ -119,6 +119,24 @@ class TelegramServer extends EventEmitter {
     }
   }
 
+  /**
+   * Obtains all updates (messages or any other content) sent or received by specified bot.
+   * Doesn't mark updates as "read".
+   * Very useful for testing `deleteMessage` Telegram API method usage.
+   */
+  getUpdatesHistory(token) {
+    const getUpdateDate = ramda.prop('date');
+    const isOwnUpdate = ramda.propEq('botToken', token);
+    return ramda.compose(
+      ramda.sortBy(getUpdateDate),
+      ramda.filter(isOwnUpdate),
+      ramda.concat
+    )(
+      this.storage.botMessages,
+      this.storage.userMessages
+    );
+  }
+
   start() {
     const app = this.webServer;
 


### PR DESCRIPTION
`getUpdatesHistory` client method obtains all updates (messages or any other content) sent or received by specified bot. Doesn't mark updates as "read". Very useful for testing `deleteMessage` Telegram API method usage.