### PR TITLE
Add deleteWebhook dummi API command

### DIFF
--- a/routes/bot/deleteWebhook.js
+++ b/routes/bot/deleteWebhook.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const {handle} = require('./utils');
+
+const deleteWebhook = (app, telegramServer)=> {
+  handle(app, '/bot:token/deleteWebhook', (req, res, unusedNext) => {
+    const data = {ok: true, result: true, description: 'Webhook was deleted'};
+    res.sendResult(data);
+  });
+};
+
+module.exports = deleteWebhook;

--- a/routes/bot/index.js
+++ b/routes/bot/index.js
@@ -7,5 +7,6 @@ module.exports = [
   require('./getUpdates'),
   require('./getMe'),
   require('./sendMessage'),
+  require('./deleteWebhook'),
   require('./unknownMethod'), // This route should go after all bot API methods.
 ];


### PR DESCRIPTION
This is necessary for compatibility with the [telegraf-js](https://github.com/telegraf/telegraf) bot framework. 

Telegraf bots on launch, when configured for polling, will [first delete any Webhooks](https://github.com/telegraf/telegraf/blob/ba2f4a2e66a149cd51efc555e01bcc21cb43ed5b/telegraf.js#L105) that are remotely setup, which prevents their use with telegram-test-api.

A dummy deleteWebhook API method implementation is provided in this PR