### PR TITLE
simple sendCallback implementation

### DIFF
--- a/modules/telegramClient.js
+++ b/modules/telegramClient.js
@@ -80,6 +80,26 @@ class TelegramClient {
     return this.makeMessage(messageText, newOptions);
   }
 
+  makeCallbackQuery(data, options = {}) {
+    const from = {id: this.userId, first_name: this.firstName, username: this.userName}
+    return merge({
+      botToken: this.botToken,
+      from: from,
+      message: {
+        from,
+        chat: {
+          id: this.chatId,
+          title: this.chatTitle,
+          first_name: this.firstName,
+          username: this.userName,
+          type: this.type,
+        },
+      },
+      date: Math.floor(Date.now() / 1000),
+      data: data,
+    }, options);
+  }
+
   async sendMessage(message) {
     const options = {
       url: `${this.url}/sendMessage`,
@@ -93,6 +113,16 @@ class TelegramClient {
   async sendCommand(message) {
     const options = {
       url: `${this.url}/sendCommand`,
+      method: 'POST',
+      data: message,
+    };
+    const res = await request(options);
+    return res && res.data;
+  }
+
+  async sendCallback(message) {
+    const options = {
+      url: `${this.url}/sendCallback`,
       method: 'POST',
       data: message,
     };

--- a/routes/bot/getUpdates.js
+++ b/routes/bot/getUpdates.js
@@ -12,6 +12,17 @@ const getUpdates = (app, telegramServer)=> {
     // turn messages into updates
     messages = messages.map((update)=> {
       update.isRead = true;
+      if ('callbackQuery' in update) {
+        return {
+          update_id: update.updateId,
+          callback_query: {
+            id: String(update.callbackId),
+            from: update.callbackQuery.from,
+            message: update.callbackQuery.message,
+            data: update.callbackQuery.data,
+          },
+        };
+      }
       return {
         update_id: update.updateId,
         message: {

--- a/routes/client/index.js
+++ b/routes/client/index.js
@@ -5,6 +5,7 @@
 module.exports = [
   require('./sendMessage'),
   require('./sendCommand'),
+  require('./sendCallback'),
   require('./getUpdates'),
   require('./getUpdatesHistory'),
 ];

--- a/routes/client/sendCallback.js
+++ b/routes/client/sendCallback.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const sendCallback = (app, telegramServer)=> {
+  app.post('/sendCallback', (req, res, next)=> {
+    telegramServer.addUserCallback(req.body);
+    const data = {ok: true, result: null};
+    res.sendResult(data);
+  });
+};
+
+module.exports = sendCallback;

--- a/telegramServer.js
+++ b/telegramServer.js
@@ -33,6 +33,7 @@ class TelegramServer extends EventEmitter {
 
     this.updateId = 1;
     this.messageId = 1;
+    this.callbackId = 1;
     this.webServer = express();
     this.webServer.use(sendResult);
     this.webServer.use(bodyParser.json());
@@ -115,6 +116,25 @@ class TelegramServer extends EventEmitter {
     this.messageId++;
     this.updateId++;
     this.emit('AddedUserCommand');
+  }
+
+  addUserCallback(callbackQuery) {
+    assert.ok(callbackQuery.botToken, 'The callbackQuery must be of type object and must contain `botToken` field.');
+    const d = new Date();
+    const millis = d.getTime();
+    const add = {
+      time: millis,
+      botToken: callbackQuery.botToken,
+      callbackQuery,
+      updateId: this.updateId,
+      messageId: this.messageId,
+      callbackId: this.callbackId,
+      isRead: false,
+    };
+    this.storage.userMessages.push(add);
+    this.updateId++;
+    this.callbackId++;
+    this.emit('AddedUserMessage');
   }
 
   messageFilter(message) {

--- a/test/telegraf-test.js
+++ b/test/telegraf-test.js
@@ -14,6 +14,7 @@ describe('Telegram bot test', () => {
       // the options passed to Telegraf in this format will make it try to get messages from the server's local URL
       const bot = new Telegraf(token, { telegram: { apiRoot: server.ApiURL } });
       bot.command('start', (ctx) => ctx.reply('Hi!'));
+      bot.on('callback_query', (ctx) => ctx.reply('pong'));
       bot.startPolling();
     });
   });
@@ -28,5 +29,16 @@ describe('Telegram bot test', () => {
     const updates = await client.getUpdates();
     assert.equal(updates.ok, true);
     assert.equal(updates.result.length, 1, 'updates queue should contain one message!');
+  });
+
+  it('should respond pong to callback_query', async () => {
+    const client = server.getClient(token, { timeout: 5000 });
+    const cb = client.makeCallbackQuery('ping');
+    const res = await client.sendCallback(cb);
+    assert.equal(res.ok, true);
+    const updates = await client.getUpdates();
+    assert.equal(updates.ok, true);
+    assert.equal(updates.result.length, 1, 'updates queue should contain one message!');
+    assert.equal(updates.result[0].message.text, 'pong', 'message should be pong!');
   });
 });


### PR DESCRIPTION
I've make client possible to send callback_query server and bot can recieve them

```
const message = tclient.makeCallbackQuery('somedata')
await tclient.sendCallback(message)
```

This is a limited implementation, you cannot answer to those callbacks in bot. But is is enough to test receiving of callback_query's