### PR TITLE
Fix periodic cleanup

### DIFF
--- a/telegramServer.js
+++ b/telegramServer.js
@@ -158,7 +158,7 @@ class TelegramServer extends EventEmitter {
     if (!this.started) {
       return;
     }
-    this.cleanUpDaemonInterval = setInterval(this.cleanUp, this.config.storeTimeout);
+    this.cleanUpDaemonInterval = setInterval(this.cleanUp.bind(this), this.config.storeTimeout);
   }
 
   /**


### PR DESCRIPTION
Current master with a default config fails once it reaches the `storeTimeout`:
```
> telegram-test-api@2.4.5 start /home/vladimir/dev/telegram-test-api
> DEBUG=TelegramServer:* node --use_strict ./bin/start

  TelegramServer:server Telegram API server config: {"protocol":"http","host":"localhost","port":9000,"storage":"RAM","storeTimeout":60000} +0ms
  TelegramServer:server Telegram API server is up on port 9000 in development mode +11ms
  TelegramServer:storage clearing storage +0ms
/home/vladimir/dev/telegram-test-api/telegramServer.js:149
    debugStorage(`current userMessages storage: ${this.storage.userMessages.length}`);
                                                               ^

TypeError: Cannot read property 'userMessages' of undefined
    at Timeout.cleanUp [as _onTimeout] (/home/vladimir/dev/telegram-test-api/telegramServer.js:149:64)
    at ontimeout (timers.js:498:11)
    at tryOnTimeout (timers.js:323:5)
    at Timer.listOnTimeout (timers.js:290:5)
```
