### PR TITLE
Make webhooks work with user's commands and callback queries

### DIFF
--- a/modules/formatUpdate.js
+++ b/modules/formatUpdate.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const formatUpdate = (update) => {
+  if ('callbackQuery' in update) {
+    return {
+      update_id: update.updateId,
+      callback_query: {
+        id: String(update.callbackId),
+        from: update.callbackQuery.from,
+        message: update.callbackQuery.message,
+        data: update.callbackQuery.data,
+      },
+    };
+  }
+  return {
+    update_id: update.updateId,
+    message: {
+      message_id: update.messageId,
+      from: update.message.from,
+      chat: update.message.chat,
+      date: update.message.date,
+      text: update.message.text,
+      entities: update.entities,
+    },
+  };
+};
+
+module.exports = formatUpdate;

--- a/package-lock.json
+++ b/package-lock.json
@@ -478,9 +478,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -493,9 +493,9 @@
       }
     },
     "anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -638,11 +638,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "balanced-match": {
@@ -850,19 +850,19 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "clean-stack": {
@@ -1978,9 +1978,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -2448,6 +2448,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
     "is-windows": {
@@ -3019,33 +3025,32 @@
       }
     },
     "mocha": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
-      "integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
+      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.1",
-        "debug": "4.3.1",
+        "chokidar": "3.5.2",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "4.0.0",
-        "log-symbols": "4.0.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.20",
-        "serialize-javascript": "5.0.1",
+        "nanoid": "3.1.25",
+        "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
-        "workerpool": "6.1.0",
+        "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
@@ -3056,6 +3061,23 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
         },
         "escape-string-regexp": {
           "version": "4.0.0",
@@ -3073,6 +3095,20 @@
             "path-exists": "^4.0.0"
           }
         },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3080,9 +3116,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
           "dev": true,
           "requires": {
             "argparse": "^2.0.1"
@@ -3095,6 +3131,16 @@
           "dev": true,
           "requires": {
             "p-locate": "^5.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
           }
         },
         "ms": {
@@ -3150,9 +3196,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nanoid": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "natural-compare": {
@@ -3823,9 +3869,9 @@
       }
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
@@ -4038,9 +4084,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
@@ -4582,48 +4628,6 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -4637,9 +4641,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
+      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
       "dev": true
     },
     "wrap-ansi": {
@@ -4722,9 +4726,9 @@
       }
     },
     "y18n": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "axios": "~0.21.1",
+    "axios": "0.21.4",
     "bluebird": "~3.7.2",
     "body-parser": "~1.19.0",
     "debug": "~4.3.1",
@@ -65,7 +65,7 @@
     "husky": "^5.0.9",
     "istanbul": "~0.4.5",
     "lint-staged": "^10.5.4",
-    "mocha": "^8.3.0",
+    "mocha": "9.1.3",
     "node-telegram-bot-api": "~0.51.0",
     "nyc": "^15.1.0",
     "telegraf": "3.38.0"

--- a/routes/bot/getMe.js
+++ b/routes/bot/getMe.js
@@ -2,9 +2,8 @@
 
 const {handle} = require('./utils');
 
-const getMe = (app, telegramServer)=> {
+const getMe = (app)=> {
   handle(app, '/bot:token/getMe', (req, res, unusedNext) => {
-    const botToken = req.params.token;
     const result = {
       username: 'Test Name',
       first_name: 'Test First name',

--- a/routes/bot/getUpdates.js
+++ b/routes/bot/getUpdates.js
@@ -11,6 +11,7 @@ const getUpdates = (app, telegramServer)=> {
     ));
     // turn messages into updates
     messages = messages.map((update)=> {
+      // eslint-disable-next-line no-param-reassign
       update.isRead = true;
       if ('callbackQuery' in update) {
         return {

--- a/routes/bot/getUpdates.js
+++ b/routes/bot/getUpdates.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const formatUpdate = require('../../modules/formatUpdate');
 const {handle} = require('./utils');
 
 const getUpdates = (app, telegramServer)=> {
@@ -13,28 +14,7 @@ const getUpdates = (app, telegramServer)=> {
     messages = messages.map((update)=> {
       // eslint-disable-next-line no-param-reassign
       update.isRead = true;
-      if ('callbackQuery' in update) {
-        return {
-          update_id: update.updateId,
-          callback_query: {
-            id: String(update.callbackId),
-            from: update.callbackQuery.from,
-            message: update.callbackQuery.message,
-            data: update.callbackQuery.data,
-          },
-        };
-      }
-      return {
-        update_id: update.updateId,
-        message: {
-          message_id: update.messageId,
-          from: update.message.from,
-          chat: update.message.chat,
-          date: update.message.date,
-          text: update.message.text,
-          entities: update.entities,
-        },
-      };
+      return formatUpdate(update);
     });
     const data = {ok: true, result: messages};
     res.sendResult(data);

--- a/routes/bot/setWebhook.js
+++ b/routes/bot/setWebhook.js
@@ -1,11 +1,14 @@
 'use strict';
 
+const assert = require('assert');
 const {handle} = require('./utils');
 
 const sendMessage = (app, telegramServer)=> {
   handle(app, '/bot:token/setWebhook', (req, res, unusedNext) => {
     const botToken = req.params.token;
-    telegramServer.setWebhook(req.body, botToken);
+    const webHook = req.body.url ? req.body : req.query;
+    assert.ok(webHook.url, 'Webhook must have a `url` defined');
+    telegramServer.setWebhook(webHook, botToken);
     const data = {ok: true, result: null};
     res.sendResult(data);
   });

--- a/routes/client/getUpdates.js
+++ b/routes/client/getUpdates.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const getUpdates = (app, telegramServer)=> {
-  app.post('/getUpdates', (req, res, next)=> {
+  app.post('/getUpdates', (req, res)=> {
     const botToken = req.body.token;
     let messages = telegramServer.storage.botMessages.filter((update)=> (
       update.botToken === botToken && !update.isRead
     ));
     // turn messages into updates
     messages = messages.map((update)=> {
+      // eslint-disable-next-line no-param-reassign
       update.isRead = true;
       return update;
     });

--- a/routes/client/sendCallback.js
+++ b/routes/client/sendCallback.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const sendCallback = (app, telegramServer)=> {
-  app.post('/sendCallback', (req, res, next)=> {
+  app.post('/sendCallback', (req, res)=> {
     telegramServer.addUserCallback(req.body);
     const data = {ok: true, result: null};
     res.sendResult(data);

--- a/routes/client/sendCommand.js
+++ b/routes/client/sendCommand.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const sendCommand = (app, telegramServer)=> {
-  app.post('/sendCommand', (req, res, next)=> {
+  app.post('/sendCommand', (req, res)=> {
     telegramServer.addUserCommand(req.body);
     const data = {ok: true, result: null};
     res.sendResult(data);

--- a/routes/client/sendMessage.js
+++ b/routes/client/sendMessage.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const sendMessage = (app, telegramServer)=> {
-  app.post('/sendMessage', (req, res, next)=> {
+  app.post('/sendMessage', (req, res)=> {
     telegramServer.addUserMessage(req.body);
     const data = {ok: true, result: null};
     res.sendResult(data);

--- a/telegramServer.js
+++ b/telegramServer.js
@@ -15,6 +15,7 @@ const sendResult = require('./modules/sendResult.js');
 const TelegramClient = require('./modules/telegramClient.js');
 const requestLogger = require('./modules/requestLogger.js');
 const Routes = require('./routes/index');
+const formatUpdate = require('./modules/formatUpdate.js');
 
 function clone(data) {
   return JSON.parse(JSON.stringify(data));
@@ -83,25 +84,44 @@ class TelegramServer extends EventEmitter {
   }
 
   async addUserMessage(message) {
+    await this.addUserUpdate(message, {message});
+    this.messageId++;
+    this.emit('AddedUserMessage');
+  }
+
+  async addUserCommand(message) {
+    assert.ok(message.entities, 'Command should have entities');
+    await this.addUserUpdate(message, {message, entities: message.entities});
+    this.messageId++;
+    this.emit('AddedUserCommand');
+  }
+
+  async addUserCallback(callbackQuery) {
+    await this.addUserUpdate(callbackQuery, {callbackQuery, callbackId: this.callbackId});
+    this.callbackId++;
+    this.emit('AddedUserCallbackQuery');
+  }
+
+  /** @private */
+  async addUserUpdate(message, updateFields) {
     assert.ok(message.botToken, 'The message must be of type object and must contain `botToken` field.');
     const d = new Date();
     const millis = d.getTime();
     const add = {
       time: millis,
       botToken: message.botToken,
-      message,
       updateId: this.updateId,
       messageId: this.messageId,
       isRead: false,
+      ...updateFields,
     };
-    this.messageId++;
     this.updateId++;
     const webhook = this.webhooks[message.botToken];
     if (webhook) {
       const options = {
         url: webhook.url,
         method: 'POST',
-        data: add,
+        data: formatUpdate(add),
       };
       const resp = await request(options);
       if (resp.status > 204) {
@@ -117,46 +137,6 @@ class TelegramServer extends EventEmitter {
     } else {
       this.storage.userMessages.push(add);
     }
-    this.emit('AddedUserMessage');
-  }
-
-  addUserCommand(message) {
-    assert.ok(message.botToken, 'The message must be of type object and must contain `botToken` field.');
-    assert.ok(message.entities, 'Command should have entities');
-    const d = new Date();
-    const millis = d.getTime();
-    const add = {
-      time: millis,
-      botToken: message.botToken,
-      message,
-      updateId: this.updateId,
-      messageId: this.messageId,
-      isRead: false,
-      entities: message.entities,
-    };
-    this.storage.userMessages.push(add);
-    this.messageId++;
-    this.updateId++;
-    this.emit('AddedUserCommand');
-  }
-
-  addUserCallback(callbackQuery) {
-    assert.ok(callbackQuery.botToken, 'The callbackQuery must be of type object and must contain `botToken` field.');
-    const d = new Date();
-    const millis = d.getTime();
-    const add = {
-      time: millis,
-      botToken: callbackQuery.botToken,
-      callbackQuery,
-      updateId: this.updateId,
-      messageId: this.messageId,
-      callbackId: this.callbackId,
-      isRead: false,
-    };
-    this.storage.userMessages.push(add);
-    this.updateId++;
-    this.callbackId++;
-    this.emit('AddedUserMessage');
   }
 
   messageFilter(message) {

--- a/telegramServer.js
+++ b/telegramServer.js
@@ -80,7 +80,11 @@ class TelegramServer extends EventEmitter {
   }
 
   async waitUserMessage() {
-    return new Promise((resolve) => this.on('AddedUserMessage', () => resolve()));
+    return new Promise((resolve) => {
+      this.on('AddedUserMessage', () => resolve());
+      this.on('AddedUserCommand', () => resolve());
+      this.on('AddedUserCallbackQuery', () => resolve());
+    });
   }
 
   async addUserMessage(message) {

--- a/telegramServer.js
+++ b/telegramServer.js
@@ -200,11 +200,11 @@ class TelegramServer extends EventEmitter {
       Routes[i](app, self);
     }
     // there was no route to process request
-    app.use((req, res, next) => {
+    app.use((req, res) => {
       res.sendError(new Error('Route not found'));
     });
     // Catch express bodyParser error, like http://stackoverflow.com/questions/15819337/catch-express-bodyparser-error
-    app.use((error, req, res, next) => {
+    app.use((error, req, res) => {
       debug(`Error: ${error}`);
       res.sendError(new Error(`Something went wrong. ${error}`));
     });

--- a/test/node-telegram-bot-api-test.js
+++ b/test/node-telegram-bot-api-test.js
@@ -24,7 +24,7 @@ class Logger {
 
 class TestBot {
   constructor(bot) {
-    bot.onText(/\/ping/, (msg, match) => {
+    bot.onText(/\/ping/, (msg) => {
       const chatId = msg.from.id;
       const opts = {
         reply_to_message_id: msg.message_id,
@@ -35,7 +35,7 @@ class TestBot {
       bot.sendMessage(chatId, 'pong', opts);
     });
 
-    bot.onText(/\/start/, (msg, match) => {
+    bot.onText(/\/start/, (msg) => {
       const chatId = msg.from.id;
       const opts = {
         reply_to_message_id: msg.message_id,
@@ -46,7 +46,7 @@ class TestBot {
       bot.sendMessage(chatId, 'What is your name?', opts);
     });
 
-    bot.onText(/Masha/, (msg, match) => {
+    bot.onText(/Masha/, (msg) => {
       const chatId = msg.from.id;
       const opts = {
         reply_to_message_id: msg.message_id,
@@ -57,7 +57,7 @@ class TestBot {
       bot.sendMessage(chatId, 'Hello, Masha!', opts);
     });
 
-    bot.onText(/Sasha/, (msg, match) => {
+    bot.onText(/Sasha/, (msg) => {
       const chatId = msg.from.id;
       const opts = {
         reply_to_message_id: msg.message_id,
@@ -162,7 +162,7 @@ describe('Telegram Server', () => {
     assert.equal(true, res.ok);
     const botOptions = {polling: true, baseApiUrl: server.ApiURL};
     const telegramBot = new TelegramBotEx(token, botOptions);
-    const testBot = new TestBot(telegramBot);
+    const unusedTestBot = new TestBot(telegramBot);
     const res2 = await telegramBot.waitForReceiveUpdate();
     assert.equal('/start', res2.text);
     debug('Stopping polling');
@@ -182,7 +182,7 @@ describe('Telegram Server', () => {
     assert.equal(true, res.ok);
     const botOptions = {polling: true, baseApiUrl: server.ApiURL};
     const telegramBot = new TelegramBotEx(token, botOptions);
-    const testBot = new TestBot(telegramBot);
+    const unusedTestBot = new TestBot(telegramBot);
     const res2 = await telegramBot.waitForReceiveUpdate();
     assert.equal('/start', res2.text);
     debug('Stopping polling');
@@ -202,7 +202,7 @@ describe('Telegram Server', () => {
     assert.equal(true, res.ok);
     const botOptions = {polling: true, baseApiUrl: server.ApiURL};
     const telegramBot = new TelegramBotEx(token, botOptions);
-    const testBot = new TestBot(telegramBot);
+    const unusedTestBot = new TestBot(telegramBot);
     const updates = await client.getUpdates();
     Logger.serverUpdate(updates.result);
     assert.equal(1, updates.result.length, 'Updates queue should contain one message!');
@@ -226,7 +226,7 @@ describe('Telegram Server', () => {
     assert.equal(true, res.ok);
     const botOptions = {polling: true, baseApiUrl: server.ApiURL};
     const telegramBot = new TelegramBotEx(token, botOptions);
-    const testBot = new TestBot(telegramBot);
+    const unusedTestBot = new TestBot(telegramBot);
     const updates = await client.getUpdates();
     Logger.serverUpdate(updates.result);
     assert.equal(1, updates.result.length, 'Updates queue should contain one message!');


### PR DESCRIPTION
Hello! I want to use `telegram-test-api ` to test my Telegram-related project, which heavily relies on webhooks. While been working on tests I've noticed that `telegram-test-api `: 
1. Doesn't trigger webhooks on commands and callback queries,
2. Sends updates on user's messages in wrong format (`updateId` instead of `update_id` etc.).

In this PR I've:
1. Covered actual webhook triggering with tests,
2. Extracted common part of update handling in "private" method and used it in all three cases (for messages, commands and callback queries),
3. Extracted update formatting and used it in both `/getUpdates` and webhook handling.

**NOTE** First two commits contain only fixes of `npm audit` and `npm run lint` commands.