### PR TITLE
Add /editMessageText, /answerCallbackQuery, fix client.getUpdates

### DIFF
--- a/src/modules/telegramClient.ts
+++ b/src/modules/telegramClient.ts
@@ -216,7 +216,7 @@ export class TelegramClient {
   }
 
   async getUpdates(): Promise<GetUpdatesResponse> {
-    const data = { token: this.botToken };
+    const data = { token: this.botToken, chatId: this.chatId };
     const update = await request({
       url: `${this.url}/getUpdates`,
       method: 'POST',

--- a/src/modules/telegramClient.ts
+++ b/src/modules/telegramClient.ts
@@ -7,6 +7,8 @@ import { GetUpdatesResponse } from '../routes/client/getUpdates';
 import { GetUpdatesHistoryResponse } from '../routes/client/getUpdatesHistory';
 
 export interface CommonMessage {
+  message_id?: number;
+  text?: string;
   from: User;
   chat: Chat;
 }

--- a/src/routes/bot/answerCallbackQuery.ts
+++ b/src/routes/bot/answerCallbackQuery.ts
@@ -1,0 +1,14 @@
+import { handle } from './utils';
+import { Route } from '../route';
+/**
+ * This route does nothing, it just stops spinner on keyboard button
+ * @see https://core.telegram.org/bots/api#answercallbackquery
+ */
+export const answerCallbackQuery: Route = (app) => {
+  handle(app, '/bot:token/answerCallbackQuery', (req, res) => {
+    res.sendResult({
+      ok: true,
+      result: null,
+    });
+  });
+};

--- a/src/routes/bot/answerCallbackQuery.ts
+++ b/src/routes/bot/answerCallbackQuery.ts
@@ -1,5 +1,5 @@
 import { handle } from './utils';
-import { Route } from '../route';
+import type { Route } from '../route';
 /**
  * This route does nothing, it just stops spinner on keyboard button
  * @see https://core.telegram.org/bots/api#answercallbackquery

--- a/src/routes/bot/answerCallbackQuery.ts
+++ b/src/routes/bot/answerCallbackQuery.ts
@@ -5,6 +5,7 @@ import type { Route } from '../route';
  * @see https://core.telegram.org/bots/api#answercallbackquery
  */
 export const answerCallbackQuery: Route = (app) => {
+  // @ts-expect-error TS6133: 'unusedTestBot' is declared but its value is never read.
   handle(app, '/bot:token/answerCallbackQuery', (req, res) => {
     res.sendResult({
       ok: true,

--- a/src/routes/bot/editMessageText.ts
+++ b/src/routes/bot/editMessageText.ts
@@ -1,0 +1,10 @@
+import { handle } from './utils';
+import { Route } from '../route';
+
+export const editMessageText: Route = (app, telegramServer) => {
+  handle(app, '/bot:token/editMessageText', (req, res, unusedNext) => {
+    telegramServer.editMessageText(req.body);
+    const data = {ok: true, result: null};
+    res.sendResult(data);
+  });
+};

--- a/src/routes/bot/editMessageText.ts
+++ b/src/routes/bot/editMessageText.ts
@@ -1,8 +1,8 @@
 import { handle } from './utils';
-import { Route } from '../route';
+import type { Route } from '../route';
 
 export const editMessageText: Route = (app, telegramServer) => {
-  handle(app, '/bot:token/editMessageText', (req, res, unusedNext) => {
+  handle(app, '/bot:token/editMessageText', (req, res, _next) => {
     telegramServer.editMessageText(req.body);
     const data = {ok: true, result: null};
     res.sendResult(data);

--- a/src/routes/bot/index.ts
+++ b/src/routes/bot/index.ts
@@ -1,6 +1,7 @@
 import { deleteMessage } from './deleteMessage';
 import { getUpdates } from './getUpdates';
 import { getMe } from './getMe';
+import { answerCallbackQuery } from './answerCallbackQuery';
 import { sendMessage } from './sendMessage';
 import { editMessageText } from './editMessageText';
 import { setWebhook } from './setWebhook';
@@ -10,6 +11,7 @@ import { unknownMethod } from './unknownMethod';
 export const botRoutes = [
   deleteMessage,
   getUpdates,
+  answerCallbackQuery,
   getMe,
   editMessageText,
   sendMessage,

--- a/src/routes/bot/index.ts
+++ b/src/routes/bot/index.ts
@@ -2,6 +2,7 @@ import { deleteMessage } from './deleteMessage';
 import { getUpdates } from './getUpdates';
 import { getMe } from './getMe';
 import { sendMessage } from './sendMessage';
+import { editMessageText } from './editMessageText';
 import { setWebhook } from './setWebhook';
 import { deleteWebhook } from './deleteWebhook';
 import { unknownMethod } from './unknownMethod';
@@ -10,6 +11,7 @@ export const botRoutes = [
   deleteMessage,
   getUpdates,
   getMe,
+  editMessageText,
   sendMessage,
   setWebhook,
   deleteWebhook,

--- a/src/routes/client/getUpdates.ts
+++ b/src/routes/client/getUpdates.ts
@@ -5,7 +5,11 @@ export const getUpdates: Route = (app, telegramServer) => {
   app.post('/getUpdates', (req, res) => {
     const botToken = req.body.token;
     const messages = telegramServer.storage.botMessages.filter(
-      (update) => update.botToken === botToken && !update.isRead,
+      (update) => (
+        update.botToken === botToken
+          && String(update.message.chat_id) === String(req.body.chatId)
+          && !update.isRead
+      ),
     );
     // mark updates as read
     messages.forEach((update) => {

--- a/src/telegramServer.ts
+++ b/src/telegramServer.ts
@@ -33,12 +33,15 @@ interface StoredUpdate {
   isRead: boolean;
 }
 
-// TODO instead of `any` here must be `InputFile` whatever that is
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type BotIncommingMessage = Params<'sendMessage', any>[0] & {
+type BotIncommingMessage = Params<'sendMessage', never>[0] & {
   // TODO parse reply_markup to its actual type, see https://git.io/J1kiM
   reply_markup?: string;
 };
+
+type BotEditTextIncommingMessage = Params<'editMessageText', never>[0] & {
+  reply_markup?: string;
+};
+
 export interface StoredBotUpdate extends StoredUpdate {
   message: BotIncommingMessage;
 }
@@ -170,6 +173,25 @@ export class TelegramServer extends EventEmitter {
     this.messageId++;
     this.updateId++;
     this.emit('AddedBotMessage');
+  }
+
+  editMessageText(message: BotEditTextIncommingMessage) {
+    const update = this.storage.botMessages.find(
+      (u) =>(
+        String(u.messageId) === String(message.message_id)
+        && String(u.message.chat_id) === String(message.chat_id)
+      ),
+    );
+    if (update) {
+      update.message = {...update.message, ...message };
+      this.emit('EditedMessageText');
+    }
+  }
+
+  async waitBotEdits() {
+    return new Promise<void>((resolve) => {
+      this.on('EditedMessageText', () => resolve());
+    });
   }
 
   async waitBotMessage() {

--- a/src/test/generic.test.ts
+++ b/src/test/generic.test.ts
@@ -132,6 +132,7 @@ describe('Telegram Server', () => {
     const { server, client } = await getServerAndClient(token);
     const botOptions = {polling: true, baseApiUrl: server.config.apiURL};
     const telegramBot = new TelegramBotEx(token, botOptions);
+    // @ts-expect-error TS6133: 'unusedTestBot' is declared but its value is never read.
     const unusedTestBot = new TestBot(telegramBot);
     const client2 = server.getClient(token, {chatId: 2, firstName: 'Second User'});
     await client.sendMessage(client.makeMessage('/start'));

--- a/src/test/generic.test.ts
+++ b/src/test/generic.test.ts
@@ -125,6 +125,22 @@ describe('Telegram Server', () => {
     );
   });
 
+  it('should get updates only for respective client', async () => {
+    const { server, client } = await getServerAndClient(token);
+    const botOptions = {polling: true, baseApiUrl: server.config.apiURL};
+    const telegramBot = new TelegramBotEx(token, botOptions);
+    const unusedTestBot = new TestBot(telegramBot);
+    const client2 = server.getClient(token, {chatId: 2, firstName: 'Second User'});
+    await client.sendMessage(client.makeMessage('/start'));
+    await client2.sendMessage(client2.makeMessage('/start'));
+    const updates = await client.getUpdates();
+    const updates2 = await client2.getUpdates();
+    assert.equal(updates.result.length, 1);
+    assert.equal(updates2.result.length, 1);
+    await telegramBot.stopPolling();
+    await server.stop();
+  });
+
   it('should get updates history', async () => {
     const { server, client } = await getServerAndClient(token);
     let message = client.makeMessage('/start');

--- a/src/test/testBots.ts
+++ b/src/test/testBots.ts
@@ -21,7 +21,7 @@ export class Logger {
 export class TestBot {
   constructor(bot: TelegramBot) {
     bot.onText(/\/ping/, (msg) => {
-      const chatId = msg.from?.id;
+      const chatId = msg.chat.id;
       if (!chatId) return;
       const opts = {
         reply_to_message_id: msg.message_id,
@@ -33,7 +33,7 @@ export class TestBot {
     });
 
     bot.onText(/\/start/, (msg) => {
-      const chatId = msg.from?.id;
+      const chatId = msg.chat.id;
       if (!chatId) return;
       const opts = {
         reply_to_message_id: msg.message_id,
@@ -45,7 +45,7 @@ export class TestBot {
     });
 
     bot.onText(/Masha/, (msg) => {
-      const chatId = msg.from?.id;
+      const chatId = msg.chat.id;
       if (!chatId) return;
       const opts = {
         reply_to_message_id: msg.message_id,
@@ -57,7 +57,7 @@ export class TestBot {
     });
 
     bot.onText(/Sasha/, (msg) => {
-      const chatId = msg.from?.id;
+      const chatId = msg.chat.id;
       if (!chatId) return;
       const opts = {
         reply_to_message_id: msg.message_id,


### PR DESCRIPTION
In this PR:
- added support for  [`/editMessageText`](https://core.telegram.org/bots/api#editmessagetext), which is necessary to leverage all the power of inline keyboards
- added support for [`/answerCallbackQuery`](https://core.telegram.org/bots/api#answercallbackquery), which is necessary to remove spinner from inline keyboards
- fix `client.getUpdates()` so that it returns and mark as read only updates intended for current client (chat)
