### PR TITLE
fix event emitter leak warning

### DIFF
--- a/src/telegramServer.ts
+++ b/src/telegramServer.ts
@@ -219,35 +219,21 @@ export class TelegramServer extends EventEmitter {
 
   async waitBotEdits() {
     return new Promise<void>((resolve) => {
-      const handler = () => {
-        this.off('EditedMessageText', handler);
-        resolve();
-      };
-      this.on('EditedMessageText', handler);
+      this.once('EditedMessageText', () => resolve());
     });
   }
 
   async waitBotMessage() {
     return new Promise<void>((resolve) => {
-      const handler = () => {
-        this.off('AddedBotMessage', handler);
-        resolve();
-      };
-      this.on('AddedBotMessage', handler);
+      this.once('AddedBotMessage', () => resolve());
     });
   }
 
   async waitUserMessage() {
     return new Promise<void>((resolve) => {
-      const messageHandler = () => {
-        this.off('AddedUserMessage', messageHandler);
-        this.off('AddedUserCommand', messageHandler);
-        this.off('AddedUserCallbackQuery', messageHandler);
-        resolve();
-      };
-      this.on('AddedUserMessage', messageHandler);
-      this.on('AddedUserCommand', messageHandler);
-      this.on('AddedUserCallbackQuery', messageHandler);
+      this.once('AddedUserMessage', () => resolve());
+      this.once('AddedUserCommand', () => resolve());
+      this.once('AddedUserCallbackQuery', () => resolve());
     });
   }
 

--- a/src/telegramServer.ts
+++ b/src/telegramServer.ts
@@ -231,9 +231,15 @@ export class TelegramServer extends EventEmitter {
 
   async waitUserMessage() {
     return new Promise<void>((resolve) => {
-      this.once('AddedUserMessage', () => resolve());
-      this.once('AddedUserCommand', () => resolve());
-      this.once('AddedUserCallbackQuery', () => resolve());
+      const messageHandler = () => {
+        this.off('AddedUserMessage', messageHandler);
+        this.off('AddedUserCommand', messageHandler);
+        this.off('AddedUserCallbackQuery', messageHandler);
+        resolve();
+      };
+      this.on('AddedUserMessage', messageHandler);
+      this.on('AddedUserCommand', messageHandler);
+      this.on('AddedUserCallbackQuery', messageHandler);
     });
   }
 

--- a/src/telegramServer.ts
+++ b/src/telegramServer.ts
@@ -262,7 +262,6 @@ export class TelegramServer extends EventEmitter {
 
   async addUserCommand(message: CommandRequest) {
     assert.ok(message.entities, 'Command should have entities');
-
     await this.addUserUpdate({
       ...this.getCommonFields(message.botToken),
       message,

--- a/src/telegramServer.ts
+++ b/src/telegramServer.ts
@@ -217,29 +217,37 @@ export class TelegramServer extends EventEmitter {
     }
   }
 
-  /**
-   * @FIXME
-   * (node:103570) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11
-   * EditedMessageText listeners added to [TelegramServer]. Use emitter.setMaxListeners() to
-   * increase limit (Use `node --trace-warnings ...` to show where the warning was created)
-   */
   async waitBotEdits() {
     return new Promise<void>((resolve) => {
-      this.on('EditedMessageText', () => resolve());
+      const handler = () => {
+        this.off('EditedMessageText', handler);
+        resolve();
+      };
+      this.on('EditedMessageText', handler);
     });
   }
 
   async waitBotMessage() {
     return new Promise<void>((resolve) => {
-      this.on('AddedBotMessage', () => resolve());
+      const handler = () => {
+        this.off('AddedBotMessage', handler);
+        resolve();
+      };
+      this.on('AddedBotMessage', handler);
     });
   }
 
   async waitUserMessage() {
     return new Promise<void>((resolve) => {
-      this.on('AddedUserMessage', () => resolve());
-      this.on('AddedUserCommand', () => resolve());
-      this.on('AddedUserCallbackQuery', () => resolve());
+      const messageHandler = () => {
+        this.off('AddedUserMessage', messageHandler);
+        this.off('AddedUserCommand', messageHandler);
+        this.off('AddedUserCallbackQuery', messageHandler);
+        resolve();
+      };
+      this.on('AddedUserMessage', messageHandler);
+      this.on('AddedUserCommand', messageHandler);
+      this.on('AddedUserCallbackQuery', messageHandler);
     });
   }
 

--- a/src/test/generic.test.ts
+++ b/src/test/generic.test.ts
@@ -138,6 +138,15 @@ describe('Telegram Server', () => {
     }).catch((err) => assert.fail(err));
   });
 
+  it('waits user message', async () => {
+    const { server, client } = await getServerAndClient(token);
+    client.sendCommand(client.makeCommand('/start'));
+    await server.waitUserMessage();
+    const history = await client.getUpdatesHistory();
+    assert.equal(history.length, 1);
+    await server.stop();
+  });
+
   it('should fully implement user-bot interaction', async () => {
     const { server, client } = await getServerAndClient(token);
     let message = client.makeMessage('/start');


### PR DESCRIPTION
I have a really long integration test suite, that listens a lot on server edit messages. It was giving me these warnings:
```
 (node:103570) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11
 EditedMessageText listeners added to [TelegramServer]. Use emitter.setMaxListeners() to
 increase limit (Use `node --trace-warnings ...` to show where the warning was created)
```