### PR TITLE
make bot username botAPI copliant

### DIFF
--- a/src/routes/bot/getMe.ts
+++ b/src/routes/bot/getMe.ts
@@ -4,7 +4,7 @@ import type { Route } from '../route';
 export const getMe: Route = (app) => {
   handle(app, '/bot:token/getMe', (_req, res, _next) => {
     const result = {
-      username: 'Test Name',
+      username: 'TestNameBot',
       first_name: 'Test First name',
       id: 666,
     };


### PR DESCRIPTION
as stated here https://core.telegram.org/bots#4-how-are-bots-different-from-humans

`Bot usernames always end in 'bot' (e.g. @TriviaBot, @GitHub_bot).`

they also never have spaces in them.

thus returning "Test Name" is unrealistic, I'm proposing "TestNameBot" as an alternative