### PR TITLE
Adds `editMessageReplyMarkup` method support

### DIFF
--- a/src/routes/bot/editMessageReplyMarkup.ts
+++ b/src/routes/bot/editMessageReplyMarkup.ts
@@ -1,0 +1,10 @@
+import { handle } from './utils';
+import type { Route } from '../route';
+
+export const editMessageReplyMarkup: Route = (app,telegramServer) => {
+  handle(app, '/bot:token/editMessageReplyMarkup', (req, res, _next) => {
+    telegramServer.editMessageReplyMarkup(req.body);
+    const data = {ok: true, result: null};
+    res.sendResult(data);
+  });
+};

--- a/src/routes/bot/editMessageReplyMarkup.ts
+++ b/src/routes/bot/editMessageReplyMarkup.ts
@@ -1,7 +1,7 @@
 import { handle } from './utils';
 import type { Route } from '../route';
 
-export const editMessageReplyMarkup: Route = (app,telegramServer) => {
+export const editMessageReplyMarkup: Route = (app, telegramServer) => {
   handle(app, '/bot:token/editMessageReplyMarkup', (req, res, _next) => {
     telegramServer.editMessageReplyMarkup(req.body);
     const data = {ok: true, result: null};

--- a/src/routes/bot/index.ts
+++ b/src/routes/bot/index.ts
@@ -4,6 +4,7 @@ import { getMe } from './getMe';
 import { answerCallbackQuery } from './answerCallbackQuery';
 import { sendMessage } from './sendMessage';
 import { editMessageText } from './editMessageText';
+import { editMessageReplyMarkup } from './editMessageReplyMarkup';
 import { setWebhook } from './setWebhook';
 import { deleteWebhook } from './deleteWebhook';
 import { unknownMethod } from './unknownMethod';
@@ -14,6 +15,7 @@ export const botRoutes = [
   answerCallbackQuery,
   getMe,
   editMessageText,
+  editMessageReplyMarkup,
   sendMessage,
   setWebhook,
   deleteWebhook,

--- a/src/telegramServer.ts
+++ b/src/telegramServer.ts
@@ -41,6 +41,7 @@ interface StoredUpdate {
 type BotIncommingMessage = Params<'sendMessage', never>[0];
 
 type BotEditTextIncommingMessage = Params<'editMessageText', never>[0];
+type BotEditReplyMarkupIncommingMessage = Params<'editMessageReplyMarkup', never>[0];
 
 type RawIncommingMessage = {
   reply_markup?: string | object;
@@ -214,6 +215,23 @@ export class TelegramServer extends EventEmitter {
     if (update) {
       update.message = {...update.message, ...message };
       this.emit('EditedMessageText');
+    }
+  }
+
+  editMessageReplyMarkup(rawMessage: BotEditReplyMarkupIncommingMessage) {
+    const message = TelegramServer.normalizeMessage(rawMessage);
+    // only InlineKeyboardMarkup is allowed in response
+    if (message.reply_markup && 'inline_keyboard' in message.reply_markup) {
+      const update = this.storage.botMessages.find(
+        (u) =>(
+          String(u.messageId) === String(message.message_id)
+          && String(u.message.chat_id) === String(message.chat_id)
+        ),
+      );
+      if (update) {
+        update.message = {...update.message, ...message };
+        this.emit('EditedMessageReplyMarkup');
+      }
     }
   }
 

--- a/src/telegramServer.ts
+++ b/src/telegramServer.ts
@@ -238,6 +238,7 @@ export class TelegramServer extends EventEmitter {
   async waitBotEdits() {
     return new Promise<void>((resolve) => {
       this.once('EditedMessageText', () => resolve());
+      this.once('EditedMessageReplyMarkup', () => resolve());
     });
   }
 


### PR DESCRIPTION
I added the `editMessageReplyMarkup` support. It is restricted to change only `reply_markup.inline_keyboard` like in `addBotMessage` method. 

This method is very useful when testing bots where are dynamic inline keyboards, which change after user pick something.

Also I added test for it.