### PR TITLE
Extendable routes, mockApi and clientOptions in storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "telegram-test-api",
+  "name": "@vishtar/telegram-test-api",
   "version": "4.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "telegram-test-api",
+      "name": "@vishtar/telegram-test-api",
       "version": "4.2.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vishtar/telegram-test-api",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Emulating telegram API",
   "keywords": [
     "telegram",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@vishtar/telegram-test-api",
-  "version": "4.2.3",
+  "name": "telegram-test-api",
+  "version": "4.2.1",
   "description": "Emulating telegram API",
   "keywords": [
     "telegram",
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/vishtar/telegram-test-api"
+    "url": "https://github.com/jehy/telegram-test-api"
   },
   "author": "Jehy <npm@jehy.ru> https://github.com/jehy",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "telegram-test-api",
-  "version": "4.2.1",
+  "name": "@vishtar/telegram-test-api",
+  "version": "4.2.2",
   "description": "Emulating telegram API",
   "keywords": [
     "telegram",
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jehy/telegram-test-api"
+    "url": "https://github.com/vishtar/telegram-test-api"
   },
   "author": "Jehy <npm@jehy.ru> https://github.com/jehy",
   "contributors": [

--- a/src/modules/telegramClient.ts
+++ b/src/modules/telegramClient.ts
@@ -68,25 +68,25 @@ const delay = promisify(setTimeout);
  * @constructor
  */
 export class TelegramClient {
-  private userId: number;
+  public userId: Readonly<number>;
 
   private timeout: number;
 
   private interval: number;
 
-  private chatId: number;
+  public chatId: Readonly<number>;
 
-  private firstName: string;
+  public firstName: string;
 
-  private userName: string;
+  public userName: string;
 
-  private chatTitle: string;
+  public chatTitle: string;
 
   private url: string;
 
   private botToken: string;
 
-  private type: 'private' | 'group' | 'supergroup' | 'channel';
+  public type: Readonly<'private' | 'group' | 'supergroup' | 'channel'>;
 
   constructor(
     url: string,


### PR DESCRIPTION
I need more APIs than this library has, but there is no easy way to add new routes and store mock data for new APIs.

Mock data can be stored in an extended class, etc. But the native way seems better.

Example of expandable routes:

```typescript
// Generic type
export class TelegramServerWrapper extends TelegramServer<{
  getChat: Record<number | string, Partial<ChatFromGetChat>>
  getChatAdministrators: Record<number | string, Partial<ChatMemberAdministrator>[]>
  getChatMembersCount: Record<number | string, number>
}> {
  constructor(config?: Partial<TelegramServerConfig>) {
    super(config, {
      // Custom routes
      routes: [getChat, getChatAdministrators, getChatMembersCount],
    })
  }
}
```

And custom route:
```typescript
export const getChat: TExpressRoute = (app, telegramServer) => {
  handle(app, '/bot:token/getChat', (req, res, _next) => {
    const isChatIdNumber = typeof req.body.chat_id === 'number'
    const chat_id = isChatIdNumber ? req.body.chat_id : req.body.chat_id.replace('@', '')
    // There is an example of mocked data
    const data = { ok: true, result: telegramServer.storage.mockApi.getChat[chat_id] }
    // @ts-expect-error .sendResult() in any
    res.sendResult(data)
  })
}
```

I also apretiate the ability to store exist client options to use it in mocks:
```typescript
tgServer.storage.mockApi.getChatAdministrators = {
      [testChannel]: [
        {
          user: {
            id: tgClient.userId,
            is_bot: false,
            first_name: tgClient.firstName,
          },
        },
      ],
    }
```

What do you think?